### PR TITLE
Add .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+.babelrc


### PR DESCRIPTION
Thanks for this package!  It looks like it's going to be super-useful for us.

We're having a problem using it in a react-native project, however.

Based on our research, it looks like that in order to allow this package to work with react-native, it is necessary to exclude the `.babelrc` file from the npm package.

This is an unfortunate limitation in the react-native packager, but at present it is the best-known solution to the problem.

See https://github.com/facebook/react-native/issues/4062 for details.